### PR TITLE
Replace `TemplateOnce` with `TemplateSimple`

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use chrono::{TimeZone, Utc};
-use sailfish::TemplateOnce;
+use sailfish::TemplateSimple;
 
 fn get_age() -> u8 {
     let utc = Utc;
@@ -13,7 +13,7 @@ fn get_age() -> u8 {
     age as u8
 }
 
-#[derive(TemplateOnce)]
+#[derive(TemplateSimple)]
 #[template(path = "index.stpl")]
 struct IndexPage {
     age: u8,

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,9 +1,9 @@
 use std::fs;
 
 use chrono::Utc;
-use sailfish::TemplateOnce;
+use sailfish::TemplateSimple;
 
-#[derive(TemplateOnce)]
+#[derive(TemplateSimple)]
 #[template(path = "links.stpl")]
 struct LinksPage {
     title: &'static str,


### PR DESCRIPTION
Replaces `TemplateOnce` with `TemplateSimple` in Sailfish to fix template compilation errors.