### PR TITLE
Remove deprecated `wrangler pages publish` command from GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages publish out --project-name=www --branch=main
+          command: pages deploy out --project-name=www --branch=main


### PR DESCRIPTION
The GHA workflow for deploying this site currently uses the `wrangler pages publish` command, which is deprecated. The solution is to replace the command with `wrangler pages deploy`, which accepts the same command arguments.